### PR TITLE
Update CAM_INFO.XML to censor serial number, and formatted for readability

### DIFF
--- a/CAM_INFO.XML
+++ b/CAM_INFO.XML
@@ -1,1 +1,100 @@
-<?xml version="1.0"?><Canon><CameraInfo><Serial>102240001057</Serial><FirmwareVer><Internal>0.5.6.0</Internal><Major>1.0.3</Major></FirmwareVer><ErrorList><Kind><ID>E70</ID><Count>4</Count><ErrorLog><BatTemperature>max:0 min:0</BatTemperature><FirstOccurTime>2021.12.11 22:29:24</FirstOccurTime><LastOccurTime>2024.05.23 22:06:27</LastOccurTime><Log><DateTime>2024.05.23 22:06:27</DateTime><Reason>DS-EID:101</Reason><BatTemperature>0</BatTemperature><LensID>00000000</LensID><ReleaseCount>12799</ReleaseCount></Log><Log><DateTime>2024.05.16 21:22:58</DateTime><Reason>DS-EID:101</Reason><BatTemperature>0</BatTemperature><LensID>00000000</LensID><ReleaseCount>12796</ReleaseCount></Log><Log><DateTime>2021.12.31 22:32:58</DateTime><Reason>DS-EID:101</Reason><BatTemperature>0</BatTemperature><LensID>0000103e</LensID><ReleaseCount>11116</ReleaseCount></Log><Log><DateTime>2021.12.11 22:29:24</DateTime><Reason>DS-EID:101</Reason><BatTemperature>0</BatTemperature><LensID>0000103c</LensID><ReleaseCount>10283</ReleaseCount></Log></ErrorLog></Kind><Kind><ID>E01</ID><Count>2</Count><ErrorLog><BatTemperature>max:0 min:0</BatTemperature><FirstOccurTime>2021.12.30 13:44:37</FirstOccurTime><LastOccurTime>2021.12.30 13:44:49</LastOccurTime><Log><DateTime>2021.12.30 13:44:49</DateTime><Reason>DS-EID:060</Reason><BatTemperature>0</BatTemperature><LensID>00000000</LensID><ReleaseCount>11105</ReleaseCount></Log><Log><DateTime>2021.12.30 13:44:37</DateTime><Reason>DS-EID:060</Reason><BatTemperature>0</BatTemperature><LensID>00000000</LensID><ReleaseCount>11104</ReleaseCount></Log></ErrorLog></Kind><Kind><ID>E02</ID><Count>2</Count><ErrorLog><BatTemperature>max:0 min:0</BatTemperature><FirstOccurTime>2022.01.19 19:35:49</FirstOccurTime><LastOccurTime>2022.10.17 13:01:41</LastOccurTime><Log><DateTime>2022.10.17 13:01:41</DateTime><Reason>DS-EID:110</Reason><BatTemperature>0</BatTemperature><LensID>0000103c</LensID><ReleaseCount>12045</ReleaseCount></Log><Log><DateTime>2022.01.19 19:35:49</DateTime><Reason>DS-EID:110</Reason><BatTemperature>0</BatTemperature><LensID>00000000</LensID><ReleaseCount>11475</ReleaseCount></Log></ErrorLog></Kind></ErrorList><TotalShoot>12800</TotalShoot><TotalShutter>15360</TotalShutter><TotalMirror>6798</TotalMirror><PowerOnCount>1232</PowerOnCount><TotalRunningTime>359521</TotalRunningTime></CameraInfo></Canon>
+<?xml version="1.0"?>
+<Canon>
+	<CameraInfo>
+		<Serial>xxxxxxxxxxxxxxxx</Serial>
+		<FirmwareVer>
+			<Internal>0.5.6.0</Internal>
+			<Major>1.0.3</Major>
+		</FirmwareVer>
+		<ErrorList>
+			<Kind>
+				<ID>E70</ID>
+				<Count>4</Count>
+				<ErrorLog>
+					<BatTemperature>max:0 min:0</BatTemperature>
+					<FirstOccurTime>2021.12.11 22:29:24</FirstOccurTime>
+					<LastOccurTime>2024.05.23 22:06:27</LastOccurTime>
+					<Log>
+						<DateTime>2024.05.23 22:06:27</DateTime>
+						<Reason>DS-EID:101</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>00000000</LensID>
+						<ReleaseCount>12799</ReleaseCount>
+					</Log>
+					<Log>
+						<DateTime>2024.05.16 21:22:58</DateTime>
+						<Reason>DS-EID:101</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>00000000</LensID>
+						<ReleaseCount>12796</ReleaseCount>
+					</Log>
+					<Log>
+						<DateTime>2021.12.31 22:32:58</DateTime>
+						<Reason>DS-EID:101</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>0000103e</LensID>
+						<ReleaseCount>11116</ReleaseCount>
+					</Log>
+					<Log>
+						<DateTime>2021.12.11 22:29:24</DateTime>
+						<Reason>DS-EID:101</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>0000103c</LensID>
+						<ReleaseCount>10283</ReleaseCount>
+					</Log>
+				</ErrorLog>
+			</Kind>
+			<Kind>
+				<ID>E01</ID>
+				<Count>2</Count>
+				<ErrorLog>
+					<BatTemperature>max:0 min:0</BatTemperature>
+					<FirstOccurTime>2021.12.30 13:44:37</FirstOccurTime>
+					<LastOccurTime>2021.12.30 13:44:49</LastOccurTime>
+					<Log>
+						<DateTime>2021.12.30 13:44:49</DateTime>
+						<Reason>DS-EID:060</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>00000000</LensID>
+						<ReleaseCount>11105</ReleaseCount>
+					</Log>
+					<Log>
+						<DateTime>2021.12.30 13:44:37</DateTime>
+						<Reason>DS-EID:060</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>00000000</LensID>
+						<ReleaseCount>11104</ReleaseCount>
+					</Log>
+				</ErrorLog>
+			</Kind>
+			<Kind>
+				<ID>E02</ID>
+				<Count>2</Count>
+				<ErrorLog>
+					<BatTemperature>max:0 min:0</BatTemperature>
+					<FirstOccurTime>2022.01.19 19:35:49</FirstOccurTime>
+					<LastOccurTime>2022.10.17 13:01:41</LastOccurTime>
+					<Log>
+						<DateTime>2022.10.17 13:01:41</DateTime>
+						<Reason>DS-EID:110</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>0000103c</LensID>
+						<ReleaseCount>12045</ReleaseCount>
+					</Log>
+					<Log>
+						<DateTime>2022.01.19 19:35:49</DateTime>
+						<Reason>DS-EID:110</Reason>
+						<BatTemperature>0</BatTemperature>
+						<LensID>00000000</LensID>
+						<ReleaseCount>11475</ReleaseCount>
+					</Log>
+				</ErrorLog>
+			</Kind>
+		</ErrorList>
+		<TotalShoot>12800</TotalShoot>
+		<TotalShutter>15360</TotalShutter>
+		<TotalMirror>6798</TotalMirror>
+		<PowerOnCount>1232</PowerOnCount>
+		<TotalRunningTime>359521</TotalRunningTime>
+	</CameraInfo>
+</Canon>


### PR DESCRIPTION
This does not prevent people from going into the previous commits and retrieving your serial number.

This is not exactly a big deal, but you might want to keep it hidden
You can rebase to remove/edit this so the previous commits will not exist, and your serial is redacted 